### PR TITLE
Improvements to allow scripts to run locally

### DIFF
--- a/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
+++ b/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
@@ -1,1 +1,167 @@
-{"cells":[{"cell_type":"markdown","id":"31dcdde2","metadata":{},"source":["### Configurations\n","\n","Please enter your configurations in the cell below. Ensure you fill out all"]},{"cell_type":"code","execution_count":null,"id":"6e7774ab-750e-4be0-9e4e-840db6a9f03c","metadata":{},"outputs":[],"source":["# Azure config\n","azure_client_id = \"<client_id>\"\n","azure_tenant_id = \"<tenant_id>\"\n","azure_client_secret = \"<client_secret>\"\n","\n","# Azure Synapse workspace config\n","synapse_workspace_name = \"<synapse_workspace_name>\"\n","\n","# Fabric config\n","workspace_id = \"<workspace_id>\"\n","lakehouse_id = \"<lakehouse_id>\"\n","export_folder_name = f\"export/{synapse_workspace_name}\"\n","prefix = \"mig\" # this prefix is used during import {prefix}{notebook_name}\n","\n","output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""]},{"cell_type":"markdown","id":"78b25461-6def-4305-a279-4aa54d2aed45","metadata":{"nteract":{"transient":{"deleting":false}}},"source":["### Export notebooks from Azure Synapse\n","\n","This will export all notebooks from your Azure Synapse workspace to the indicated `output_folder` in ipynb format"]},{"cell_type":"code","execution_count":null,"id":"367d03b8-b112-493f-bd4c-0fd5c82b7ae2","metadata":{"jupyter":{"outputs_hidden":false,"source_hidden":false},"nteract":{"transient":{"deleting":false}}},"outputs":[],"source":["sc.addPyFile('https://raw.githubusercontent.com/microsoft/fabric-migration/main/data-engineering/utils/util.py')\n","from util import *\n","\n","Utils.export_notebooks(azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder)"]},{"cell_type":"markdown","id":"3f9666d3-d5a2-42b6-8039-f43226efbe50","metadata":{"nteract":{"transient":{"deleting":false}}},"source":["### Import notebooks in Fabric\n","\n","This will import all notebooks from indicated `output_folder` into Fabric"]},{"cell_type":"code","execution_count":null,"id":"74d7ab32-0e34-48c3-b5eb-27a47401bf5a","metadata":{"jupyter":{"outputs_hidden":false,"source_hidden":false},"nteract":{"transient":{"deleting":false}}},"outputs":[],"source":["Utils.import_notebooks(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, prefix)"]}],"metadata":{"kernel_info":{"name":"synapse_pyspark"},"kernelspec":{"display_name":"Synapse PySpark","language":"Python","name":"synapse_pyspark"},"language_info":{"name":"python"},"microsoft":{"host":{},"language":"python","ms_spell_check":{"ms_spell_check_language":"en"}},"notebook_environment":{},"nteract":{"version":"nteract-front-end@1.0.0"},"save_output":true,"spark_compute":{"compute_id":"/trident/default","session_options":{"conf":{},"enableDebugMode":false}},"synapse_widget":{"state":{},"version":"0.1"},"trident":{"lakehouse":{"default_lakehouse":"6de03ae5-29d1-41dd-bac1-556d8d3748cc","default_lakehouse_name":"lkmigration01","default_lakehouse_workspace_id":"abd75642-04a6-4f1a-bf3a-cd9adbea0cbe","known_lakehouses":[{"id":"6de03ae5-29d1-41dd-bac1-556d8d3748cc"}]}},"widgets":{}},"nbformat":4,"nbformat_minor":5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "31dcdde2",
+   "metadata": {},
+   "source": [
+    "### Configurations\n",
+    "\n",
+    "Please enter your configurations in the cell below. Ensure you fill out all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e7774ab-750e-4be0-9e4e-840db6a9f03c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.identity import ClientSecretCredential\n",
+    "\n",
+    "# Azure config\n",
+    "azure_client_id = \"<client_id>\"\n",
+    "azure_tenant_id = \"<tenant_id>\"\n",
+    "azure_client_secret = \"<client_secret>\"\n",
+    "credential = ClientSecretCredential(azure_tenant_id, azure_client_id, azure_client_secret)\n",
+    "\n",
+    "# Azure Synapse workspace config\n",
+    "synapse_workspace_name = \"<synapse_workspace_name>\"\n",
+    "\n",
+    "# Fabric config\n",
+    "workspace_id = \"<workspace_id>\"\n",
+    "lakehouse_id = \"<lakehouse_id>\"\n",
+    "export_folder_name = f\"export/{synapse_workspace_name}\"\n",
+    "prefix = \"mig\" # this prefix is used during import {prefix}{notebook_name}\n",
+    "\n",
+    "output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78b25461-6def-4305-a279-4aa54d2aed45",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Export notebooks from Azure Synapse\n",
+    "\n",
+    "This will export all notebooks from your Azure Synapse workspace to the indicated `output_folder` in ipynb format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "367d03b8-b112-493f-bd4c-0fd5c82b7ae2",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sc.addPyFile('https://raw.githubusercontent.com/microsoft/fabric-migration/main/data-engineering/utils/util.py')\n",
+    "from util import *\n",
+    "\n",
+    "Utils.export_notebooks(credential, synapse_workspace_name, output_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f9666d3-d5a2-42b6-8039-f43226efbe50",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Import notebooks in Fabric\n",
+    "\n",
+    "This will import all notebooks from indicated `output_folder` into Fabric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74d7ab32-0e34-48c3-b5eb-27a47401bf5a",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Utils.import_notebooks(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, prefix)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
+  "kernelspec": {
+   "display_name": "Synapse PySpark",
+   "language": "Python",
+   "name": "synapse_pyspark"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "host": {},
+   "language": "python",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "notebook_environment": {},
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "save_output": true,
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "conf": {},
+    "enableDebugMode": false
+   }
+  },
+  "synapse_widget": {
+   "state": {},
+   "version": "0.1"
+  },
+  "trident": {
+   "lakehouse": {
+    "default_lakehouse": "6de03ae5-29d1-41dd-bac1-556d8d3748cc",
+    "default_lakehouse_name": "lkmigration01",
+    "default_lakehouse_workspace_id": "abd75642-04a6-4f1a-bf3a-cd9adbea0cbe",
+    "known_lakehouses": [
+     {
+      "id": "6de03ae5-29d1-41dd-bac1-556d8d3748cc"
+     }
+    ]
+   }
+  },
+  "widgets": {}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
+++ b/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
@@ -108,7 +108,7 @@
    },
    "outputs": [],
    "source": [
-    "Utils.import_notebooks(output_folder, workspace_id, prefix)"
+    "Utils.import_notebooks(FabricSparkUtilitiesCredential(), output_folder, workspace_id, prefix)"
    ]
   }
  ],

--- a/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
+++ b/data-engineering/spark-notebooks/nt-notebook-export-import.ipynb
@@ -30,11 +30,10 @@
     "\n",
     "# Fabric config\n",
     "workspace_id = \"<workspace_id>\"\n",
-    "lakehouse_id = \"<lakehouse_id>\"\n",
     "export_folder_name = f\"export/{synapse_workspace_name}\"\n",
     "prefix = \"mig\" # this prefix is used during import {prefix}{notebook_name}\n",
     "\n",
-    "output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""
+    "output_folder = f\"/lakehouse/default/Files/{export_folder_name}\""
    ]
   },
   {
@@ -109,7 +108,7 @@
    },
    "outputs": [],
    "source": [
-    "Utils.import_notebooks(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, prefix)"
+    "Utils.import_notebooks(output_folder, workspace_id, prefix)"
    ]
   }
  ],

--- a/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
+++ b/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Utils.import_sjds(output_folder, workspace_id, lakehouse_id, prefix)"
+    "Utils.import_sjds(FabricSparkUtilitiesCredential(), output_folder, workspace_id, lakehouse_id, prefix)"
    ]
   }
  ],

--- a/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
+++ b/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
@@ -1,1 +1,170 @@
-{"cells":[{"cell_type":"markdown","id":"2d822f86-31bd-4f72-95e8-d0fdc7688c78","metadata":{"nteract":{"transient":{"deleting":false}}},"source":["### Configurations\n","\n","Please enter your configurations in the cell below. Ensure you fill out all"]},{"cell_type":"code","execution_count":null,"id":"43094e04-f15b-4d82-9e68-728c2e79236b","metadata":{"jupyter":{"outputs_hidden":false,"source_hidden":false},"nteract":{"transient":{"deleting":false}}},"outputs":[],"source":["# Azure config\n","azure_client_id = \"<client_id>\"\n","azure_tenant_id = \"<tenant_id>\"\n","azure_client_secret = \"<client_secret>\"\n","\n","# Azure Synapse workspace config\n","synapse_workspace_name = \"<synapse_workspace_name>\"\n","\n","# Fabric config\n","workspace_id = \"<workspace_ip>\"\n","lakehouse_id = \"<lakehouse_id>\"\n","export_folder_name = f\"export/{synapse_workspace_name}\"\n","prefix = \"mig\" # this prefix is used during import {prefix}{sjd_name}\n","\n","output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""]},{"cell_type":"markdown","id":"7150021f-ca48-441d-a43e-59ef2cd0f163","metadata":{"nteract":{"transient":{"deleting":false}}},"source":["### Export SJD from Azure Synapse\n","\n","This will export all SJDs from your Azure Synapse workspace to the indicated `output_folder` in json format"]},{"cell_type":"code","execution_count":null,"id":"d709b0b1-fe3d-4584-84ca-14438ee5362e","metadata":{"jupyter":{"outputs_hidden":false,"source_hidden":false},"nteract":{"transient":{"deleting":false}}},"outputs":[],"source":["sc.addPyFile('https://raw.githubusercontent.com/microsoft/fabric-migration/main/data-engineering/utils/util.py')\n","from util import *\n","\n","Utils.export_sjd(azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder)"]},{"cell_type":"markdown","id":"76042a5e-30ba-48c4-89e1-73e436984c56","metadata":{"nteract":{"transient":{"deleting":false}}},"source":["### Import SJD in Fabric\n","\n","This will import all SJD from indicated `output_folder` into Fabric"]},{"cell_type":"code","execution_count":null,"id":"eac0f785","metadata":{},"outputs":[],"source":["Utils.import_sjds(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, lakehouse_id, prefix)"]}],"metadata":{"kernel_info":{"name":"synapse_pyspark"},"kernelspec":{"display_name":"Synapse PySpark","language":"Python","name":"synapse_pyspark"},"language_info":{"name":"python"},"microsoft":{"host":{},"language":"python"},"notebook_environment":{},"nteract":{"version":"nteract-front-end@1.0.0"},"save_output":true,"spark_compute":{"compute_id":"/trident/default","session_options":{"conf":{},"enableDebugMode":false}},"synapse_widget":{"state":{},"version":"0.1"},"trident":{"lakehouse":{"default_lakehouse":"6de03ae5-29d1-41dd-bac1-556d8d3748cc","default_lakehouse_name":"lkmigration01","default_lakehouse_workspace_id":"abd75642-04a6-4f1a-bf3a-cd9adbea0cbe","known_lakehouses":[{"id":"6de03ae5-29d1-41dd-bac1-556d8d3748cc"}]}},"widgets":{}},"nbformat":4,"nbformat_minor":5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2d822f86-31bd-4f72-95e8-d0fdc7688c78",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Configurations\n",
+    "\n",
+    "Please enter your configurations in the cell below. Ensure you fill out all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43094e04-f15b-4d82-9e68-728c2e79236b",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from azure.identity import ClientSecretCredential\n",
+    "\n",
+    "# Azure config\n",
+    "azure_client_id = \"<client_id>\"\n",
+    "azure_tenant_id = \"<tenant_id>\"\n",
+    "azure_client_secret = \"<client_secret>\"\n",
+    "credential = ClientSecretCredential(azure_tenant_id, azure_client_id, azure_client_secret)\n",
+    "\n",
+    "# Azure Synapse workspace config\n",
+    "synapse_workspace_name = \"<synapse_workspace_name>\"\n",
+    "\n",
+    "# Fabric config\n",
+    "workspace_id = \"<workspace_id>\"\n",
+    "lakehouse_id = \"<lakehouse_id>\"\n",
+    "export_folder_name = f\"export/{synapse_workspace_name}\"\n",
+    "prefix = \"mig\" # this prefix is used during import {prefix}{sjd_name}\n",
+    "\n",
+    "output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7150021f-ca48-441d-a43e-59ef2cd0f163",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Export SJD from Azure Synapse\n",
+    "\n",
+    "This will export all SJDs from your Azure Synapse workspace to the indicated `output_folder` in json format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d709b0b1-fe3d-4584-84ca-14438ee5362e",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sc.addPyFile('https://raw.githubusercontent.com/microsoft/fabric-migration/main/data-engineering/utils/util.py')\n",
+    "from util import *\n",
+    "\n",
+    "Utils.export_sjd(credential, synapse_workspace_name, output_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76042a5e-30ba-48c4-89e1-73e436984c56",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Import SJD in Fabric\n",
+    "\n",
+    "This will import all SJD from indicated `output_folder` into Fabric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eac0f785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Utils.import_sjds(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, lakehouse_id, prefix)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
+  "kernelspec": {
+   "display_name": "Synapse PySpark",
+   "language": "Python",
+   "name": "synapse_pyspark"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "host": {},
+   "language": "python"
+  },
+  "notebook_environment": {},
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "save_output": true,
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "conf": {},
+    "enableDebugMode": false
+   }
+  },
+  "synapse_widget": {
+   "state": {},
+   "version": "0.1"
+  },
+  "trident": {
+   "lakehouse": {
+    "default_lakehouse": "6de03ae5-29d1-41dd-bac1-556d8d3748cc",
+    "default_lakehouse_name": "lkmigration01",
+    "default_lakehouse_workspace_id": "abd75642-04a6-4f1a-bf3a-cd9adbea0cbe",
+    "known_lakehouses": [
+     {
+      "id": "6de03ae5-29d1-41dd-bac1-556d8d3748cc"
+     }
+    ]
+   }
+  },
+  "widgets": {}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
+++ b/data-engineering/spark-sjd/nt-sjd-export-import.ipynb
@@ -50,7 +50,7 @@
     "export_folder_name = f\"export/{synapse_workspace_name}\"\n",
     "prefix = \"mig\" # this prefix is used during import {prefix}{sjd_name}\n",
     "\n",
-    "output_folder = f\"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com/{lakehouse_id}/Files/{export_folder_name}\""
+    "output_folder = f\"/lakehouse/default/Files/{export_folder_name}\""
    ]
   },
   {
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Utils.import_sjds(f\"/lakehouse/default/Files/{export_folder_name}\", workspace_id, lakehouse_id, prefix)"
+    "Utils.import_sjds(output_folder, workspace_id, lakehouse_id, prefix)"
    ]
   }
  ],

--- a/data-engineering/utils/util.py
+++ b/data-engineering/utils/util.py
@@ -8,26 +8,6 @@ from notebookutils import mssparkutils
 
 class Utils:
 
-    # Synapse utils
-
-    def get_access_token(azure_client_id, azure_tenant_id, azure_client_secret):
-        url = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/token"
-
-        payload = {
-            "grant_type": "client_credentials",
-            "client_id": {azure_client_id},
-            "client_secret": {azure_client_secret},
-            "resource": f"https://dev.azuresynapse.net/"
-        }
-
-        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-
-        response = requests.post(url, data=payload, headers=headers)
-        response_json = json.loads(response.text)
-        synapse_dev_token = response_json["access_token"]
-
-        return synapse_dev_token
-
     # Notebook utils
 
     def clean_notebook_cells(ntbk_json, tags_to_clean):
@@ -38,9 +18,9 @@ class Utils:
 
         return ntbk_json
 
-    def export_notebooks(azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder):
+    def export_notebooks(credential, synapse_workspace_name, output_folder):
         resource_type = "notebooks"
-        Utils.export_resources(resource_type, azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder)
+        Utils.export_resources(resource_type, credential, synapse_workspace_name, output_folder)
 
     def import_notebooks(output_folder, workspace_id, prefix, notebook_names=None):
         date = datetime.now().strftime('%Y_%m_%dT%H_%M_%S')
@@ -113,9 +93,9 @@ class Utils:
 
     # SJD utils
 
-    def export_sjd(azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder):
+    def export_sjd(credential, synapse_workspace_name, output_folder):
         resource_type = "sparkJobDefinitions"
-        Utils.export_resources(resource_type, azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder)
+        Utils.export_resources(resource_type, credential, synapse_workspace_name, output_folder)
 
     def import_sjd(sjd_name, sjd_json, workspace_id, overwrite=False):
 
@@ -215,11 +195,11 @@ class Utils:
 
     # Generic
 
-    def export_resources(resource_type, azure_client_id, azure_tenant_id, azure_client_secret, synapse_workspace_name, output_folder):
+    def export_resources(resource_type, credential, synapse_workspace_name, output_folder):
 
         base_uri = f"{synapse_workspace_name}.dev.azuresynapse.net"
         api_version = "2020-12-01"
-        synapse_dev_token = Utils.get_access_token(azure_client_id, azure_tenant_id, azure_client_secret)
+        synapse_dev_token = credential.get_token("https://dev.azuresynapse.net/").token
         res_exported = 0
         resources_exported = {}
 

--- a/data-engineering/utils/util.py
+++ b/data-engineering/utils/util.py
@@ -48,7 +48,10 @@ class Utils:
             if os.path.exists(file_path):
                 with open(file_path, "r", encoding='utf-8') as read_file:
                     ntbk_json = json.load(read_file)
-                ntbk_name = f"{prefix}_{notebook_name}"
+                if prefix:
+                    ntbk_name = f"{prefix}_{notebook_name}"
+                else:
+                    ntbk_name = notebook_name
                 Utils.import_notebook(credential, ntbk_name, ntbk_json, workspace_id, False)
                 res_imported += 1
 
@@ -191,7 +194,10 @@ class Utils:
             if os.path.exists(file_path):
                 with open(file_path, "r", encoding='utf-8') as read_file:
                     sjd_json = json.load(read_file)
-                full_sjd_name = f"{prefix}_{sjd_name}"
+                if prefix:
+                    full_sjd_name = f"{prefix}_{sjd_name}"
+                else:
+                    full_sjd_name = sjd_name
                 Utils.import_sjd_from_json(credential, full_sjd_name, sjd_json, workspace_id, lakehouse_id, False)
                 res_imported += 1
 

--- a/data-engineering/utils/util.py
+++ b/data-engineering/utils/util.py
@@ -242,7 +242,9 @@ class Utils:
                         file_name = f"{resource_name}.ipynb"
                         data = json.dumps(updated_ntbk_json, indent=4)
                     
-                    mssparkutils.fs.put(f"{output_folder}/{resource_type}/{file_name}", data, False)
+                    os.makedirs(f"{output_folder}/{resource_type}", exist_ok=True)
+                    with open(f"{output_folder}/{resource_type}/{file_name}", "w") as file:
+                        file.write(data)
                     res_exported += 1
                     resources_exported[resource_type] = res_exported
                     


### PR DESCRIPTION
A few improvements that allow this script to be used both in Fabric and locally:
* Allow user to pass in a credential object instead of requiring the user to use a service principal
* Use local filesystem - the code already uses the /lakehouse mount when importing, I think it makes sense to keep it consistent. Additionally, if running this locally you can use your local storage with no dependency on Azure storage
* Don't prepend _ when prefix is empty