### PR TITLE
Fix Microsoft documentation links to point to public URLs

### DIFF
--- a/data-engineering/README.md
+++ b/data-engineering/README.md
@@ -11,17 +11,17 @@ To use the migration scripts see the details below and read guidance doc for eac
 
 | Item                 | Export    | Import      |                                                                                                                                                                   |
 |----------------------|-----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Pools                | Supported | Unsupported | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-pools)                                  |
-| Configurations       | Supported | Unsupported | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-configurations)                         |
-| Libraries            | Supported | Unsupported | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-libraries)                              |
-| Notebooks            | Supported | Supported   | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-notebooks) / [scripts](spark-notebooks/)      |
-| Spark job definition | Supported | Supported   | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-job-definition) / [scripts](spark-sjd/) |
-| HMS metastore        | Supported | Supported   | [doc](https://review.learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-hms-metadata) / [scripts](spark-catalog/hms/) |
+| Pools                | Supported | Unsupported | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-pools)                                  |
+| Configurations       | Supported | Unsupported | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-configurations)                         |
+| Libraries            | Supported | Unsupported | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-libraries)                              |
+| Notebooks            | Supported | Supported   | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-notebooks) / [scripts](spark-notebooks/)      |
+| Spark job definition | Supported | Supported   | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-spark-job-definition) / [scripts](spark-sjd/) |
+| HMS metastore        | Supported | Supported   | [doc](https://learn.microsoft.com/en-us/fabric/data-engineering/migrate-synapse-hms-metadata) / [scripts](spark-catalog/hms/) |
 
  
 > **NOTE:** ADLS Gen2 ACLs, linked services, mount points, workspace users/roles, Key Vault secrets, data and pipelines migration not supported yet. 
 
-- See [differences between Fabric vs. Azure Synapse Spark](https://review.learn.microsoft.com/en-us/fabric/data-engineering/comparison-between-fabric-and-azure-synapse-spark)
+- See [differences between Fabric vs. Azure Synapse Spark](https://learn.microsoft.com/en-us/fabric/data-engineering/comparison-between-fabric-and-azure-synapse-spark)
 - See [migrating from Azure Synapse Spark to Fabric](https://aka.ms/fabric-migrate-synapse-spark)
 
 **How to use import/export scripts**


### PR DESCRIPTION
review.learn.microsoft.com is an internal URL. Instead it should point to the public./published version